### PR TITLE
pkg/fms: Parse roster in web UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  pull_request:
   push:
     tags:
       - "*"

--- a/pkg/config/team.go
+++ b/pkg/config/team.go
@@ -32,7 +32,6 @@ func LoadTeams(fr io.Reader) (map[int]*Team, error) {
 			for col := range header {
 				header[col] = strings.ReplaceAll(header[col], "Team Name", "Name")
 				header[col] = strings.ReplaceAll(header[col], "Team Number", "Number")
-				header[col] = strings.ReplaceAll(header[col], "Hub Name", "Hub")
 			}
 		} else {
 			dict := map[string]string{}

--- a/pkg/eventstream/eventstream.go
+++ b/pkg/eventstream/eventstream.go
@@ -50,6 +50,21 @@ func (es *EventStream) PublishActionStart(action, msg string) {
 	es.publish(bytes)
 }
 
+// PublishActionComplete pushes an asynchronous action complete message.
+func (es *EventStream) PublishActionComplete(action string) {
+	e := EventActionComplete{
+		Type:   EventTypeActionComplete,
+		Action: action,
+	}
+
+	bytes, err := json.Marshal(e)
+	if err != nil {
+		es.l.Warn("Error marshaling error", "error", err)
+		return
+	}
+	es.publish(bytes)
+}
+
 // PublishFileFetch pushes a filename into the event stream.
 func (es *EventStream) PublishFileFetch(file string) {
 	e := EventFileFetch{

--- a/pkg/eventstream/null.go
+++ b/pkg/eventstream/null.go
@@ -19,5 +19,8 @@ func (ns *NullStream) PublishLogLine(_ string) {}
 // PublishActionStart discards all actions.
 func (ns *NullStream) PublishActionStart(_, _ string) {}
 
+// PublishActionComplete discards all actions.
+func (ns *NullStream) PublishActionComplete(_ string) {}
+
 // PublishFileFetch discards all filenames.
 func (ns *NullStream) PublishFileFetch(_ string) {}

--- a/pkg/eventstream/type.go
+++ b/pkg/eventstream/type.go
@@ -24,6 +24,10 @@ const (
 	// attempting to process it.
 	EventTypeActionStart
 
+	// EventTypeActionComplete is used to signal that an
+	// asynchronous action has successfully completed.
+	EventTypeActionComplete
+
 	// EventTypeFileFetch is fired when a file is successfully
 	// retrieved from a remote source.
 	EventTypeFileFetch
@@ -46,6 +50,13 @@ type EventActionStart struct {
 	Type    EventType
 	Action  string
 	Message string
+}
+
+// EventActionComplete conatins an action name to signal completion
+// for.
+type EventActionComplete struct {
+	Type   EventType
+	Action string
 }
 
 // EventFileFetch contains a filename that was fetched successfully.

--- a/pkg/fms/fms.go
+++ b/pkg/fms/fms.go
@@ -102,6 +102,7 @@ func New(opts ...Option) (*FMS, error) {
 			r.Post("/fetch-tools", x.apiFetchTools)
 			r.Post("/fetch-packages", x.apiFetchPackages)
 			r.Post("/set-timezone", x.apiSetTimezone)
+			r.Post("/update-roster", x.apiUpdateRoster)
 		})
 	})
 
@@ -118,6 +119,7 @@ func New(opts ...Option) (*FMS, error) {
 
 			r.Route("/setup", func(r chi.Router) {
 				r.Get("/oob", x.uiViewOutOfBoxSetup)
+				r.Get("/roster", x.uiViewRosterForm)
 			})
 		})
 	})

--- a/pkg/fms/types.go
+++ b/pkg/fms/types.go
@@ -35,6 +35,8 @@ type EventStreamer interface {
 	Handler(nhttp.ResponseWriter, *nhttp.Request)
 
 	PublishActionStart(string, string)
+	PublishActionComplete(string)
+	PublishError(error)
 }
 
 // FileFetcher fetches restricted files that cannot be baked into the

--- a/pkg/fms/ui/p2/fragments/nav.p2
+++ b/pkg/fms/ui/p2/fragments/nav.p2
@@ -9,6 +9,7 @@
         <div class="nav-header">Setup</div>
         <div class="nav-dropdown">
           <a class="nav-item" href="/ui/admin/setup/oob">Out of Box</a>
+          <a class="nav-item" href="/ui/admin/setup/roster">Roster</a>
         </div>
       </div>
       <div class="nav-container">

--- a/pkg/fms/ui/p2/views/setup/roster.p2
+++ b/pkg/fms/ui/p2/views/setup/roster.p2
@@ -1,0 +1,98 @@
+{% extends "../../base.p2" %}
+
+{% block title %}Roster Management | Gizmo FMS{% endblock %}
+
+{% block content %}
+<div class="flex-container flex-row flex-center">
+    <div class="flex-item flex-max foreground box">
+        <h1>Roster Management</h1>
+        <p>Use this form to submit a new roster to the system.  Submitting a new roster after one has been loaded will result in teams being added and dropped to achieve a match with the new roster.  If a team exists in both old and new rosters, the security keys will be maintained (no re-bind necessary).</p>
+        <p>The file must be in CSV format, must have headers, and must have the columns <code>Number</code> and <code>Name</code> (case-sensitive) as the first two columns.</p>
+        <form>
+            <label for="roster_file">Roster File</label>
+            <input type="file" name="roster_file" id="roster_file" accept="tex/csv" />
+        </form>
+        <br />
+        <hr />
+        <br />
+
+        <div id="roster_container"></div>
+        <div id="roster_actions" class="hidden">
+            <hr />
+            <div class="flex-container flex-row flex-center">
+                <div class="flex-item">
+                    <p>If the above teams are as expected, you may submit this roster using the button below.</p>
+                    <center><button id="btn-submit-roster" class="button">Submit Roster</button></center>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+ const teams = new Map();
+
+ container = document.getElementById('roster_container');
+ document.getElementById('roster_file').addEventListener('change', function(event) {
+     const file = event.target.files[0];
+     if (file) {
+         const reader = new FileReader();
+         reader.onload = function(e) {
+             const csvText = e.target.result;
+             const lines = csvText.split(/\r?\n/);
+             lines.forEach(line => {
+                 if (line.trim() !== '') {
+                     const fields = line.split(',');
+                     if (!isNaN(fields[0])) {
+                         teams.set(fields[0], { Name: fields[1] });
+                     };
+                 }
+             });
+             console.log(teams);
+             const elements = new Array();
+             elements.push(document.createElement('p').textContent = 'Parsed ' + (teams.size-1) + ' teams:');
+             const table = document.createElement('table');
+             const tbody = document.createElement('tbody');
+             table.appendChild(tbody);
+
+             const row = document.createElement('tr');
+             const th1 = document.createElement('th');
+             th1.textContent = 'Number';
+             row.appendChild(th1);
+             const th2 = document.createElement('th');
+             th2.textContent = 'Name';
+             row.appendChild(th2);
+             tbody.appendChild(row);
+
+             for (const [number, attr] of teams) {
+                 const r = document.createElement('tr');
+                 const tdNumber = document.createElement('td');
+                 tdNumber.textContent = number;
+                 const tdName = document.createElement('td');
+                 tdName.textContent = attr.Name;
+                 r.appendChild(tdNumber);
+                 r.appendChild(tdName);
+                 tbody.appendChild(r);
+             }
+
+             elements.push(table);
+             container.replaceChildren(...elements);
+             document.getElementById('roster_actions').classList.remove('hidden');
+         };
+         reader.readAsText(file);
+     }
+ });
+
+ async function submitRoster() {
+     const response = await fetch("/api/setup/update-roster", {
+         method: "POST",
+         headers: {
+             "Content-Type": "application/json",
+         },
+         body: JSON.stringify(Object.fromEntries(teams)),
+     });
+ }
+
+ document.getElementById('btn-submit-roster').addEventListener('click', submitRoster);
+</script>
+{% endblock %}

--- a/pkg/fms/ui/static/css/theme.css
+++ b/pkg/fms/ui/static/css/theme.css
@@ -99,6 +99,10 @@ code {
     text-align: center;
 }
 
+.hidden {
+    display: none;
+}
+
 .hud-container {
     background: black;
     padding: 2%;

--- a/pkg/fms/ui/static/js/gizmo.js
+++ b/pkg/fms/ui/static/js/gizmo.js
@@ -2,7 +2,8 @@ const MsgTypeUnknown = 0;
 const MsgTypeError = 1;
 const MsgTypeLogLine = 2;
 const MsgTypeActionStart = 3;
-const MsgTypeFileFetch = 4;
+const MsgTypeActionComplete = 4;
+const MsgTypeFileFetch = 5;
 
 var ws = new ReconnectingWebSocket('ws://' + document.location.host + '/api/eventstream');
 
@@ -28,6 +29,12 @@ ws.addEventListener("message", (event) => {
             console.log(msg.Message);
             Toastify({
                 text: "Started Action: " + msg.Action + " (" + msg.Message + ")",
+                duration: 3000
+            }).showToast();
+            break;
+        case MsgTypeActionComplete:
+            Toastify({
+                text: "Completed Action: " + msg.Action,
                 duration: 3000
             }).showToast();
             break;


### PR DESCRIPTION
Allows for loading roster from the first setup experience via the web UI, rather than the console wizard.  Contributes to  #46 .

[roster_load.webm](https://github.com/user-attachments/assets/6088d35c-7242-4308-9c08-769dc976be62)
