### PR TITLE
Add web interface for bootstrapping the network.

### DIFF
--- a/internal/cmdlets/fms_net_bootstrap.go
+++ b/internal/cmdlets/fms_net_bootstrap.go
@@ -107,15 +107,6 @@ func fmsBootstrapNetCmdRun(c *cobra.Command, args []string) {
 		return
 	}
 
-	if err := controller.ActivateBootstrapNet(); err != nil {
-		appLogger.Error("Fatal error with bootstrap network", "error", err)
-		if err := controller.DeactivateBootstrapNet(); err != nil {
-			appLogger.Error("Error occured while unbootstrapping network.  You may need to run `ip link del bootstrap0`.", "error", err)
-			return
-		}
-		return
-	}
-
 	if err := controller.BootstrapPhase1(); err != nil {
 		appLogger.Error("Fatal error during Phase 1 Bootstrap", "error", err)
 		return

--- a/internal/cmdlets/fms_net_bootstrap.go
+++ b/internal/cmdlets/fms_net_bootstrap.go
@@ -3,20 +3,11 @@
 package cmdlets
 
 import (
-	"crypto/tls"
-	"errors"
 	"fmt"
-	"net/http"
-	"net/url"
 	"os"
-	"os/exec"
-	"sync"
-	"time"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/cenkalti/backoff/v4"
 	"github.com/spf13/cobra"
-	"github.com/vishvananda/netlink"
 
 	"github.com/gizmo-platform/gizmo/pkg/config"
 	rconfig "github.com/gizmo-platform/gizmo/pkg/routeros/config"
@@ -40,147 +31,7 @@ func init() {
 	fmsBootstrapNetCmd.Flags().Bool("init-only", false, "Only perform terraform initialization and exit")
 }
 
-const (
-	bootstrapAddr = "100.64.1.1"
-)
-
 func fmsBootstrapNetCmdRun(c *cobra.Command, args []string) {
-	confirm := func() bool {
-		qProceed := &survey.Confirm{
-			Message: "Acknowledge and Proceed",
-			Default: false,
-		}
-		proceed := false
-		if err := survey.AskOne(qProceed, &proceed); err != nil {
-			fmt.Fprintf(os.Stderr, "Impossible error confirming bootstrap: %s\n", err)
-		}
-		return proceed
-	}
-
-	bootstrapNet := func() error {
-		// Setup the bootstrap mode which talks via a distinct vlan to
-		// configure everything.  This is necessary since part of the
-		// setup changes the layer 2 network and we need to not change
-		// the network we're configuring from.
-		fmsAddr := "100.64.1.2"
-		appLogger.Info("Bootstrap mode enabled")
-
-		eth0, err := netlink.LinkByName("eth0")
-		if err != nil {
-			appLogger.Error("Could not retrieve ethernet link", "error", err)
-			return err
-		}
-
-		bootstrap0 := &netlink.Vlan{
-			LinkAttrs:    netlink.LinkAttrs{Name: "bootstrap0", ParentIndex: eth0.Attrs().Index},
-			VlanId:       2,
-			VlanProtocol: netlink.VLAN_PROTOCOL_8021Q,
-		}
-
-		if err := netlink.LinkAdd(bootstrap0); err != nil && err.Error() != "file exists" {
-			appLogger.Error("Could not create bootstrapping interface", "error", err)
-			return err
-		}
-
-		for _, int := range []netlink.Link{eth0, bootstrap0} {
-			if err := netlink.LinkSetUp(int); err != nil {
-				appLogger.Error("Error enabling eth0", "error", err)
-				return err
-			}
-		}
-
-		addr, _ := netlink.ParseAddr(fmsAddr + "/24")
-		if err := netlink.AddrAdd(bootstrap0, addr); err != nil {
-			appLogger.Error("Could not add IP", "error", err)
-			return err
-		}
-		return nil
-	}
-
-	unbootstrapNet := func() error {
-		bootstrap0, err := netlink.LinkByName("bootstrap0")
-		if err != nil {
-			appLogger.Error("Could not retrieve ethernet link", "error", err)
-			return err
-		}
-
-		if err := netlink.LinkDel(bootstrap0); err != nil {
-			appLogger.Error("Error removing bootstrap link", "error", err)
-			return err
-		}
-		return nil
-	}
-
-	waitForROS := func(wg *sync.WaitGroup, addr, user, pass string) {
-		defer wg.Done()
-		cl := http.Client{
-			Timeout: time.Second * 10,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
-		}
-
-		req := &http.Request{
-			Method: http.MethodGet,
-			URL: &url.URL{
-				Scheme: "http",
-				Host:   addr,
-				Path:   "/rest/system/identity",
-				User:   url.UserPassword(user, pass),
-			},
-		}
-
-		retryFunc := func() error {
-			_, err := cl.Do(req)
-			if err != nil {
-				appLogger.Info("Waiting for device", "address", addr, "error", err)
-			}
-			return err
-		}
-
-		if err := backoff.Retry(retryFunc, backoff.NewExponentialBackOff(backoff.WithMaxInterval(time.Second*30))); err != nil {
-			appLogger.Error("Permanent error encountered while waiting for RouterOS", "error", err)
-			appLogger.Error("You need to reboot network boxes and try again")
-			return
-		}
-	}
-
-	waitForFMSIP := func() error {
-		appLogger.Debug("Aquiring eth0")
-		eth0, err := netlink.LinkByName("eth0")
-		if err != nil {
-			appLogger.Error("Could not retrieve ethernet link", "error", err)
-			return err
-		}
-
-		fmsIP, _ := netlink.ParseAddr("100.64.0.2/24")
-
-		retryFunc := func() error {
-			appLogger.Debug("Requesting addresses from eth0")
-			addrs, err := netlink.AddrList(eth0, netlink.FAMILY_V4)
-			if err != nil {
-				appLogger.Error("Error listing addresses", "error", err)
-				return err
-			}
-
-			for _, a := range addrs {
-				appLogger.Debug("Checking IP", "have", a.String(), "want", fmsIP.String())
-				if a.Equal(*fmsIP) {
-					return nil
-				}
-			}
-
-			return errors.New("No FMS IP")
-		}
-		appLogger.Debug("Link acquired, waiting for address")
-
-		if err := backoff.Retry(retryFunc, backoff.NewExponentialBackOff(backoff.WithMaxInterval(time.Second*30))); err != nil {
-			appLogger.Error("Permanent error encountered while waiting for dhcp address", "error", err)
-			appLogger.Error("You may be able to recover from this by restarting dhcpcd")
-		}
-		return nil
-	}
-
 	initLogger("bootstrap-net")
 
 	skipApply, _ := c.Flags().GetBool("skip-apply")
@@ -195,15 +46,23 @@ func fmsBootstrapNetCmdRun(c *cobra.Command, args []string) {
 	controller := rconfig.New(
 		rconfig.WithFMS(fmsConf),
 		rconfig.WithLogger(appLogger),
-		rconfig.WithRouter(bootstrapAddr),
+		rconfig.WithRouter(rconfig.BootstrapAddr),
 	)
-	ctx := make(map[string]interface{})
-	ctx["RouterBootstrap"] = true
-	ctx["FieldBootstrap"] = true
 
-	// Sync with bootstrap state enabled
-	if err := controller.SyncState(ctx); err != nil {
-		appLogger.Error("Fatal error synchronizing state", "error", err)
+	confirm := func() bool {
+		qProceed := &survey.Confirm{
+			Message: "Acknowledge and Proceed",
+			Default: false,
+		}
+		proceed := false
+		if err := survey.AskOne(qProceed, &proceed); err != nil {
+			fmt.Fprintf(os.Stderr, "Impossible error confirming bootstrap: %s\n", err)
+		}
+		return proceed
+	}
+
+	if err := controller.BootstrapPhase0(); err != nil {
+		appLogger.Error("Fatal error during Phase 0", "error", err)
 		return
 	}
 
@@ -248,54 +107,17 @@ func fmsBootstrapNetCmdRun(c *cobra.Command, args []string) {
 		return
 	}
 
-	if err := bootstrapNet(); err != nil {
+	if err := controller.ActivateBootstrapNet(); err != nil {
 		appLogger.Error("Fatal error with bootstrap network", "error", err)
-		if err := unbootstrapNet(); err != nil {
+		if err := controller.DeactivateBootstrapNet(); err != nil {
 			appLogger.Error("Error occured while unbootstrapping network.  You may need to run `ip link del bootstrap0`.", "error", err)
 			return
 		}
 		return
 	}
 
-	// At this point we're ready to actually configure the root
-	// router.  This requires the TLM to sync even with empty
-	// state since that results in state files on disk.
-	if err := controller.SyncTLM(make(map[int]string)); err != nil {
-		appLogger.Error("Could not shim the TLM", "error", err)
-		return
-	}
-
-	var swg sync.WaitGroup
-	swg.Add(1)
-	go waitForROS(&swg, bootstrapAddr, fmsConf.AutoUser, fmsConf.AutoPass)
-	swg.Wait()
-
-	// We limit module.router here to configure only the scoring
-	// router.  This needs to get configured first since this sets
-	// up the DHCP reservations for the field access points.
-	// Without setting this up we wouldn't be able to assert the
-	// location of the field devices later.
-	if err := controller.Converge(true, "module.router"); err != nil {
-		appLogger.Error("Fatal error converging state", "error", err)
-		return
-	}
-	ctx["RouterBootstrap"] = false
-	if err := controller.SyncState(ctx); err != nil {
-		appLogger.Error("Fatal error syncing state", "error", err)
-		return
-	}
-	if err := controller.Converge(false, "module.router"); err != nil {
-		appLogger.Error("Fatal error converging state", "error", err)
-		return
-	}
-	if err := unbootstrapNet(); err != nil {
-		appLogger.Warn("Could not unbootstrap the local network", "error", err)
-	}
-	if err := exec.Command("dhcpcd", "--rebind", "eth0").Run(); err != nil {
-		appLogger.Warn("Could not rebind dhcpcd, you probably don't have an address!", "error", err)
-	}
-	if err := waitForFMSIP(); err != nil {
-		appLogger.Error("Did not aquire FMS IP, cannot continue!", "error", err)
+	if err := controller.BootstrapPhase1(); err != nil {
+		appLogger.Error("Fatal error during Phase 1 Bootstrap", "error", err)
 		return
 	}
 
@@ -323,51 +145,15 @@ func fmsBootstrapNetCmdRun(c *cobra.Command, args []string) {
 		return
 	}
 
-	for _, field := range fmsConf.Fields {
-		swg.Add(1)
-		go waitForROS(&swg, field.IP, fmsConf.AutoUser, fmsConf.AutoPass)
-		swg.Wait()
-		provisionFunc := func() error {
-			if err := controller.Converge(false, fmt.Sprintf("module.field%d", field.ID)); err != nil {
-				appLogger.Error("Error configuring field", "field", field.ID, "error", err)
-				return err
-			}
-			return nil
-		}
-
-		bo := backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(time.Minute * 5))
-		if err := backoff.Retry(provisionFunc, bo); err != nil {
-			appLogger.Error("Permanent error while configuring field", "error", err)
-			return
-		}
+	if err := controller.BootstrapPhase2(); err != nil {
+		appLogger.Error("Fatal error during Phase 2", "error", err)
+		return
 	}
 
 	// Toggle out of bootstrap mode
-	ctx["FieldBootstrap"] = false
-	if err := controller.SyncState(ctx); err != nil {
-		appLogger.Error("Fatal error synchronizing state", "error", err)
+	if err := controller.BootstrapPhase3(); err != nil {
+		appLogger.Error("Fatal error during Phse 3", "error", err)
 		return
-	}
-
-	if err := controller.Converge(false, "module.router"); err != nil {
-		appLogger.Error("Fatal error converging state", "error", err)
-		return
-	}
-
-	for _, field := range fmsConf.Fields {
-		provisionFunc := func() error {
-			if err := controller.Converge(false, fmt.Sprintf("module.field%d", field.ID)); err != nil {
-				appLogger.Error("Error configuring field", "field", field.ID, "error", err)
-				return err
-			}
-			return nil
-		}
-
-		bo := backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(time.Minute * 5))
-		if err := backoff.Retry(provisionFunc, bo); err != nil {
-			appLogger.Error("Permanent error while configuring field", "error", err)
-			return
-		}
 	}
 
 	appLogger.Info("Provisioning Complete")

--- a/internal/cmdlets/fms_run.go
+++ b/internal/cmdlets/fms_run.go
@@ -50,11 +50,15 @@ func fmsRunCmdRun(c *cobra.Command, args []string) {
 		return
 	}
 
+	es := eventstream.New(appLogger)
+	appLogger.Debug("EventStream Init")
+
 	routerAddr := "100.64.0.1"
 	controller := rconfig.New(
 		rconfig.WithFMS(fmsConf),
 		rconfig.WithLogger(appLogger),
 		rconfig.WithRouter(routerAddr),
+		rconfig.WithEventStreamer(es),
 	)
 	appLogger.Debug("Controller Init")
 
@@ -67,9 +71,6 @@ func fmsRunCmdRun(c *cobra.Command, args []string) {
 		appLogger.Warn("Could not recover TLM state", "error", err)
 	}
 	appLogger.Debug("TLM Init")
-
-	es := eventstream.New(appLogger)
-	appLogger.Debug("EventStream Init")
 
 	nsf := netinstall.NewFetcher(
 		netinstall.WithFetcherLogger(appLogger),
@@ -85,6 +86,7 @@ func fmsRunCmdRun(c *cobra.Command, args []string) {
 		fms.WithStartupWG(wg),
 		fms.WithEventStreamer(es),
 		fms.WithFileFetcher(nsf),
+		fms.WithNetController(controller),
 	)
 	appLogger.Debug("HTTP Init")
 

--- a/pkg/fms/fms.go
+++ b/pkg/fms/fms.go
@@ -118,6 +118,16 @@ func New(opts ...Option) (*FMS, error) {
 				r.Post("/begin-flash", x.apiDeviceFlashBegin)
 				r.Post("/cancel-flash", x.apiDeviceFlashCancel)
 			})
+
+			r.Route("/net", func(r chi.Router) {
+				r.Post("/init", x.apiInitNetController)
+				r.Route("/bootstrap", func(r chi.Router) {
+					r.Post("/phase0", x.apiBootstrapBeginPhase0)
+					r.Post("/phase1", x.apiBootstrapBeginPhase1)
+					r.Post("/phase2", x.apiBootstrapBeginPhase2)
+					r.Post("/phase3", x.apiBootstrapBeginPhase3)
+				})
+			})
 		})
 	})
 
@@ -140,6 +150,7 @@ func New(opts ...Option) (*FMS, error) {
 				r.Get("/net-advanced", x.uiViewNetAdvanced)
 				r.Get("/integrations", x.uiViewIntegrations)
 				r.Get("/flash-device", x.uiViewFlashDevice)
+				r.Get("/bootstrap-net", x.uiViewBootstrapNet)
 			})
 		})
 	})

--- a/pkg/fms/option.go
+++ b/pkg/fms/option.go
@@ -75,3 +75,12 @@ func WithFileFetcher(fetcher FileFetcher) Option {
 		return nil
 	}
 }
+
+// WithNetController injects the backend network controller that will
+// actually modify network state.
+func WithNetController(nc NetController) Option {
+	return func(f *FMS) error {
+		f.net = nc
+		return nil
+	}
+}

--- a/pkg/fms/system/tpl/gizmo-fms.run.tpl
+++ b/pkg/fms/system/tpl/gizmo-fms.run.tpl
@@ -3,4 +3,7 @@
 [ -r ./conf ] && . ./conf
 cd /var/lib/gizmo || exit 1
 [ -r fms.json ] || echo '{}' | chpst -u _gizmo tee fms.json > /dev/null
-exec chpst -u _gizmo /usr/local/bin/gizmo fms run
+export USER=_gizmo
+export HOME=/var/lib/gizmo
+exec 2>&1
+exec chpst -u _gizmo:wheel:dialout /usr/local/bin/gizmo fms run

--- a/pkg/fms/types.go
+++ b/pkg/fms/types.go
@@ -49,6 +49,20 @@ type FileFetcher interface {
 	FetchTools() error
 }
 
+// NetController abstracts the functionality of the RouterOS
+// controller so that the FMS can bootstrap and reconcile the network
+// as required.
+type NetController interface {
+	Init() error
+	SyncState(map[string]interface{}) error
+	Converge(bool, string) error
+	CycleRadio(string) error
+	BootstrapPhase0() error
+	BootstrapPhase1() error
+	BootstrapPhase2() error
+	BootstrapPhase3() error
+}
+
 type hudVersions struct {
 	HardwareVersions string
 	FirmwareVersions string
@@ -66,6 +80,7 @@ type FMS struct {
 	fetcher FileFetcher
 
 	tlm TeamLocationMapper
+	net NetController
 
 	swg *sync.WaitGroup
 	tpl *pongo2.TemplateSet

--- a/pkg/fms/ui/p2/fragments/nav.p2
+++ b/pkg/fms/ui/p2/fragments/nav.p2
@@ -15,6 +15,7 @@
           <a class="nav-item" href="/ui/admin/setup/net-wifi">WiFi Settings</a>
           <a class="nav-item" href="/ui/admin/setup/net-advanced">Advanced Network</a>
           <a class="nav-item" href="/ui/admin/setup/flash-device">Flash Device</a>
+          <a class="nav-item" href="/ui/admin/setup/bootstrap-net">Net Bootstrap</a>
         </div>
       </div>
       <div class="nav-container">

--- a/pkg/fms/ui/p2/views/setup/flash-device.p2
+++ b/pkg/fms/ui/p2/views/setup/flash-device.p2
@@ -38,6 +38,7 @@
                 <option value=1>Scoring Box (Small)</option>
                 <option value=2>Scoring Box (Large)</option>
                 <option value=3>Field Box</option>
+                <option value=4>Auxiliary Device</option>
             </select>
             <button id="btn-begin-flash">Begin Flashing</button>
             <button id="btn-cancel-flash">Cancel</button>

--- a/pkg/fms/ui/p2/views/setup/net-bootstrap.p2
+++ b/pkg/fms/ui/p2/views/setup/net-bootstrap.p2
@@ -1,0 +1,42 @@
+{% extends "../../base.p2" %}
+
+{% block title %}Network Bootstrap | Gizmo FMS{% endblock %}
+
+{% block content %}
+<div class="flex-container flex-row flex-center">
+    <div class="flex-item flex-max foreground box">
+        <h1>Network Bootstrap</h1>
+        <p>This page will guide you through bootstrapping the network for the very first time.  This process will take about 10 minutes, and will require internet access from the FMS workstation.  You can obtain this network access via either a wifi connection or USB tethered device.</p>
+
+        <div class="flex-container flex-row flex-center">
+            <button id="btn-bootstrap-init" class="button">Initialize</button>
+            <button id="btn-bootstrap-phase0" class="button">Phase 0</button>
+            <button id="btn-bootstrap-phase1" class="button">Phase 1</button>
+            <button id="btn-bootstrap-phase2" class="button">Phase 2</button>
+            <button id="btn-bootstrap-phase3" class="button">Phase 3</button>
+        </div>
+
+        <br />
+        <div class="logbox"><pre><code id="logbox"></code></pre></div>
+    </div>
+</div>
+
+<script>
+ const logbox = document.getElementById('logbox');
+
+ async function requestInit() { fetch('/api/setup/net/init', { method: 'POST' }) }
+ document.getElementById('btn-bootstrap-init').addEventListener('click', requestInit);
+
+ async function requestPhase0() { fetch('/api/setup/net/bootstrap/phase0', { method: 'POST' }) }
+ document.getElementById('btn-bootstrap-phase0').addEventListener('click', requestPhase0);
+
+ async function requestPhase1() { fetch('/api/setup/net/bootstrap/phase1', { method: 'POST' }) }
+ document.getElementById('btn-bootstrap-phase1').addEventListener('click', requestPhase1);
+
+ async function requestPhase2() { fetch('/api/setup/net/bootstrap/phase2', { method: 'POST' }) }
+ document.getElementById('btn-bootstrap-phase2').addEventListener('click', requestPhase2);
+
+ async function requestPhase3() { fetch('/api/setup/net/bootstrap/phase3', { method: 'POST' }) }
+ document.getElementById('btn-bootstrap-phase3').addEventListener('click', requestPhase3);
+</script>
+{% endblock %}

--- a/pkg/fms/web.go
+++ b/pkg/fms/web.go
@@ -265,3 +265,40 @@ func (f *FMS) apiDeviceFlashCancel(w http.ResponseWriter, r *http.Request) {
 	f.netinst.Cancel()
 	f.netinst = nil
 }
+
+func (f *FMS) apiInitNetController(w http.ResponseWriter, r *http.Request) {
+	if err := f.net.SyncState(nil); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	if err := f.net.Init(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (f *FMS) apiBootstrapBeginPhase0(w http.ResponseWriter, r *http.Request) {
+	if err := f.net.BootstrapPhase0(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (f *FMS) apiBootstrapBeginPhase1(w http.ResponseWriter, r *http.Request) {
+	if err := f.net.BootstrapPhase1(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (f *FMS) apiBootstrapBeginPhase2(w http.ResponseWriter, r *http.Request) {
+	if err := f.net.BootstrapPhase2(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (f *FMS) apiBootstrapBeginPhase3(w http.ResponseWriter, r *http.Request) {
+	if err := f.net.BootstrapPhase3(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/pkg/fms/web.go
+++ b/pkg/fms/web.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/gizmo-platform/gizmo/pkg/config"
-	"github.com/gizmo-platform/gizmo/pkg/util"
 	"github.com/gizmo-platform/gizmo/pkg/routeros/netinstall"
+	"github.com/gizmo-platform/gizmo/pkg/util"
 )
 
 func (f *FMS) apiGetConfig(w http.ResponseWriter, r *http.Request) {

--- a/pkg/fms/web_ui.go
+++ b/pkg/fms/web_ui.go
@@ -116,3 +116,7 @@ func (f *FMS) uiViewIntegrations(w http.ResponseWriter, r *http.Request) {
 func (f *FMS) uiViewFlashDevice(w http.ResponseWriter, r *http.Request) {
 	f.doTemplate(w, r, "views/setup/flash-device.p2", nil)
 }
+
+func (f *FMS) uiViewBootstrapNet(w http.ResponseWriter, r *http.Request) {
+	f.doTemplate(w, r, "views/setup/net-bootstrap.p2", nil)
+}

--- a/pkg/routeros/config/bootstrap.go
+++ b/pkg/routeros/config/bootstrap.go
@@ -4,12 +4,6 @@ import (
 	"os/exec"
 )
 
-const (
-	// BootstrapAddr points to where the scoring router would be
-	// during the bootstrap scenario.
-	BootstrapAddr = "100.64.1.1"
-)
-
 // BootstrapPhase0 sets up the intial structures on disk and gets to a
 // point where further assumptions around bootstrapping can proceed.
 func (c *Configurator) BootstrapPhase0() error {
@@ -17,15 +11,21 @@ func (c *Configurator) BootstrapPhase0() error {
 	c.ctx["FieldBootstrap"] = true
 
 	// Sync with bootstrap state enabled
+	c.es.PublishLogLine("[LOG] => Synchronizing state files")
 	if err := c.SyncState(c.ctx); err != nil {
 		c.l.Error("Fatal error synchronizing state", "error", err)
+		c.es.PublishError(err)
 		return err
 	}
 
 	if err := c.SyncTLM(make(map[int]string)); err != nil {
 		c.l.Error("Could not shim the TLM", "error", err)
+		c.es.PublishError(err)
 		return err
 	}
+	c.es.PublishLogLine("[ACTION] => Plug the FMS workstation into Scoring Box port #2 and turn it on")
+	c.es.PublishLogLine("[CLICK] => You may now click on Phase 1")
+	c.es.PublishActionComplete("Network Bootstrap (Phase 0)")
 	return nil
 }
 
@@ -33,34 +33,68 @@ func (c *Configurator) BootstrapPhase0() error {
 // where it is providing DHCP and the rest of the system is able to
 // communicate.
 func (c *Configurator) BootstrapPhase1() error {
-	if err := c.waitForROS(BootstrapAddr, c.fc.AutoUser, c.fc.AutoPass); err != nil {
-		c.l.Error("ROS is not available", "error", err)
+	c.es.PublishLogLine("[LOG] => Activating bootstrap network configuration")
+	if err := c.ActivateBootstrapNet(); err != nil {
+		c.l.Error("Error activating bootstrap net", "error", err)
+		c.es.PublishError(err)
+		if err := c.DeactivateBootstrapNet(); err != nil {
+			c.l.Warn("Could not unbootstrap the local network", "error", err)
+			c.es.PublishError(err)
+		}
 		return err
 	}
-
+	c.es.PublishLogLine("[LOG] => Waiting for connection to Scoring Box")
+	if err := c.waitForROS(BootstrapAddr, c.fc.AutoUser, c.fc.AutoPass); err != nil {
+		c.l.Error("ROS is not available", "error", err)
+		c.es.PublishError(err)
+		return err
+	}
+	c.ctx["RouterBootstrap"] = true
+	c.routerAddr = BootstrapAddr
+	if err := c.SyncState(c.ctx); err != nil {
+		c.l.Error("Error synchronizing state", "error", err)
+		c.es.PublishError(err)
+		return err
+	}
+	c.es.PublishLogLine("[LOG] => Applying configuration to Scoring Box")
 	if err := c.Converge(true, "module.router"); err != nil {
 		c.l.Error("Fatal error converging state", "error", err)
+		c.es.PublishError(err)
 		return err
 	}
 	c.ctx["RouterBootstrap"] = false
 	if err := c.SyncState(c.ctx); err != nil {
 		c.l.Error("Fatal error syncing state", "error", err)
+		c.es.PublishError(err)
 		return err
 	}
 	if err := c.Converge(false, "module.router"); err != nil {
 		c.l.Error("Fatal error converging state", "error", err)
+		c.es.PublishError(err)
 		return err
 	}
+	c.es.PublishLogLine("[LOG] => Finished configuring Scoring Box")
+	c.es.PublishLogLine("[LOG] => Deactivating bootstrap network configuration")
 	if err := c.DeactivateBootstrapNet(); err != nil {
 		c.l.Warn("Could not unbootstrap the local network", "error", err)
+		c.es.PublishError(err)
+		return err
 	}
 	if err := exec.Command("dhcpcd", "--rebind", "eth0").Run(); err != nil {
 		c.l.Warn("Could not rebind dhcpcd, you probably don't have an address!", "error", err)
+		c.es.PublishError(err)
 	}
+	c.routerAddr = NormalAddr
+	c.es.PublishLogLine("[LOG] => Waiting for FMS Workstatation to acquire network")
 	if err := c.waitForFMSIP(); err != nil {
 		c.l.Error("Did not aquire FMS IP, cannot continue!", "error", err)
+		c.es.PublishError(err)
 		return err
 	}
+	c.es.PublishLogLine("[LOG] => FMS Workstation has acquried network connection")
+	c.es.PublishLogLine("[ACTION] => Plug field(s) into port(s) 3-8 and turn them on")
+	c.es.PublishLogLine("[CLICK] => You may now click on Phase 2")
+	c.es.PublishActionComplete("Network Bootstrap (Phase 1)")
 	return nil
 }
 
@@ -69,15 +103,22 @@ func (c *Configurator) BootstrapPhase2() error {
 	c.ctx["FieldBootstrap"] = true
 
 	// Sync with bootstrap state enabled
+	c.es.PublishLogLine("[LOG] => Synchronizing state files")
 	if err := c.SyncState(c.ctx); err != nil {
 		c.l.Error("Fatal error synchronizing state", "error", err)
+		c.es.PublishError(err)
 		return err
 	}
 
+	c.es.PublishLogLine("[LOG] => Configuring Fields")
 	if err := c.convergeFields(); err != nil {
 		c.l.Error("Error converging fields", "error", err)
+		c.es.PublishError(err)
 		return err
 	}
+	c.es.PublishLogLine("[LOG] => Finished configuring fields")
+	c.es.PublishLogLine("[CLICK] => You may now click on Phase 3")
+	c.es.PublishActionComplete("Network Bootstrap (Phase 2)")
 	return nil
 }
 
@@ -85,20 +126,29 @@ func (c *Configurator) BootstrapPhase2() error {
 // system to its normal operating state.
 func (c *Configurator) BootstrapPhase3() error {
 	c.ctx["FieldBootstrap"] = false
+	c.es.PublishLogLine("[LOG] => Synchronizing state files")
 	if err := c.SyncState(c.ctx); err != nil {
 		c.l.Error("Fatal error synchronizing state", "error", err)
+		c.es.PublishError(err)
 		return err
 	}
 
+	c.es.PublishLogLine("[LOG] => Transitioning Scoring Box to normal mode")
 	if err := c.Converge(false, "module.router"); err != nil {
 		c.l.Error("Fatal error converging state", "error", err)
+		c.es.PublishError(err)
 		return err
 	}
+	c.es.PublishLogLine("[LOG] => Finished transitioning Scoring Box to normal mode")
 
+	c.es.PublishLogLine("[LOG] => Transitioning Fields to normal mode")
 	if err := c.convergeFields(); err != nil {
 		c.l.Error("Error converging fields", "error", err)
+		c.es.PublishError(err)
 		return err
 	}
-
+	c.es.PublishLogLine("[LOG] => Finished transitioning Fields to normal mode")
+	c.es.PublishLogLine("[LOG] => Bootstrap Complete")
+	c.es.PublishActionComplete("Network Bootstrap (Phase 3)")
 	return nil
 }

--- a/pkg/routeros/config/bootstrap.go
+++ b/pkg/routeros/config/bootstrap.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"os/exec"
+)
+
+const (
+	// BootstrapAddr points to where the scoring router would be
+	// during the bootstrap scenario.
+	BootstrapAddr = "100.64.1.1"
+)
+
+// BootstrapPhase0 sets up the intial structures on disk and gets to a
+// point where further assumptions around bootstrapping can proceed.
+func (c *Configurator) BootstrapPhase0() error {
+	c.ctx["RouterBootstrap"] = true
+	c.ctx["FieldBootstrap"] = true
+
+	// Sync with bootstrap state enabled
+	if err := c.SyncState(c.ctx); err != nil {
+		c.l.Error("Fatal error synchronizing state", "error", err)
+		return err
+	}
+
+	if err := c.SyncTLM(make(map[int]string)); err != nil {
+		c.l.Error("Could not shim the TLM", "error", err)
+		return err
+	}
+	return nil
+}
+
+// BootstrapPhase1 handles the bring up of the core router to a point
+// where it is providing DHCP and the rest of the system is able to
+// communicate.
+func (c *Configurator) BootstrapPhase1() error {
+	if err := c.waitForROS(BootstrapAddr, c.fc.AutoUser, c.fc.AutoPass); err != nil {
+		c.l.Error("ROS is not available", "error", err)
+		return err
+	}
+
+	if err := c.Converge(true, "module.router"); err != nil {
+		c.l.Error("Fatal error converging state", "error", err)
+		return err
+	}
+	c.ctx["RouterBootstrap"] = false
+	if err := c.SyncState(c.ctx); err != nil {
+		c.l.Error("Fatal error syncing state", "error", err)
+		return err
+	}
+	if err := c.Converge(false, "module.router"); err != nil {
+		c.l.Error("Fatal error converging state", "error", err)
+		return err
+	}
+	if err := c.DeactivateBootstrapNet(); err != nil {
+		c.l.Warn("Could not unbootstrap the local network", "error", err)
+	}
+	if err := exec.Command("dhcpcd", "--rebind", "eth0").Run(); err != nil {
+		c.l.Warn("Could not rebind dhcpcd, you probably don't have an address!", "error", err)
+	}
+	if err := c.waitForFMSIP(); err != nil {
+		c.l.Error("Did not aquire FMS IP, cannot continue!", "error", err)
+		return err
+	}
+	return nil
+}
+
+// BootstrapPhase2 handles the bootstrapping of fields.
+func (c *Configurator) BootstrapPhase2() error {
+	c.ctx["FieldBootstrap"] = true
+
+	// Sync with bootstrap state enabled
+	if err := c.SyncState(c.ctx); err != nil {
+		c.l.Error("Fatal error synchronizing state", "error", err)
+		return err
+	}
+
+	if err := c.convergeFields(); err != nil {
+		c.l.Error("Error converging fields", "error", err)
+		return err
+	}
+	return nil
+}
+
+// BootstrapPhase3 toggles out of bootstrap mode, and returns the
+// system to its normal operating state.
+func (c *Configurator) BootstrapPhase3() error {
+	c.ctx["FieldBootstrap"] = false
+	if err := c.SyncState(c.ctx); err != nil {
+		c.l.Error("Fatal error synchronizing state", "error", err)
+		return err
+	}
+
+	if err := c.Converge(false, "module.router"); err != nil {
+		c.l.Error("Fatal error converging state", "error", err)
+		return err
+	}
+
+	if err := c.convergeFields(); err != nil {
+		c.l.Error("Error converging fields", "error", err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/routeros/config/option.go
+++ b/pkg/routeros/config/option.go
@@ -21,3 +21,9 @@ func WithFMS(fms *config.FMSConfig) Option {
 func WithRouter(ip string) Option {
 	return func(c *Configurator) { c.routerAddr = ip }
 }
+
+// WithEventStreamer provides a means of streaming events that the
+// config engine takes.
+func WithEventStreamer(es EventStreamer) Option {
+	return func(c *Configurator) { c.es = es }
+}

--- a/pkg/routeros/config/type.go
+++ b/pkg/routeros/config/type.go
@@ -25,6 +25,8 @@ type Configurator struct {
 	stateDir string
 
 	routerAddr string
+
+	ctx map[string]interface{}
 }
 
 type rosInterface struct {

--- a/pkg/routeros/config/type.go
+++ b/pkg/routeros/config/type.go
@@ -16,11 +16,20 @@ var efs embed.FS
 // Option configures the Configurator
 type Option func(*Configurator)
 
+// EventStreamer provides an option to stream configuration events to
+// remote consumers.
+type EventStreamer interface {
+	PublishError(error)
+	PublishLogLine(string)
+	PublishActionComplete(string)
+}
+
 // Configurator is a mechansim to drive terraform under the hood and
 // validate that the configuration is as intended.
 type Configurator struct {
 	l  hclog.Logger
 	fc *config.FMSConfig
+	es EventStreamer
 
 	stateDir string
 

--- a/pkg/routeros/netinstall/netinstall.go
+++ b/pkg/routeros/netinstall/netinstall.go
@@ -80,7 +80,7 @@ const (
 
 // Installer wraps functionality associated with installation.
 type Installer struct {
-	l hclog.Logger
+	l  hclog.Logger
 	es EventStreamer
 
 	pkgs         []string

--- a/pkg/routeros/netinstall/option.go
+++ b/pkg/routeros/netinstall/option.go
@@ -1,6 +1,5 @@
 package netinstall
 
-
 import (
 	"github.com/hashicorp/go-hclog"
 
@@ -35,7 +34,7 @@ const (
 // given device.
 func (o OptionSet) Options() []InstallerOpt {
 	opts := []InstallerOpt{}
-	switch (o) {
+	switch o {
 	case HardwareScoringBox:
 		opts = append(opts, WithBootstrapNet(BootstrapNetScoring))
 		opts = append(opts, WithPackages([]string{


### PR DESCRIPTION
The network bootstrap procedure is now available via the web interface.  This works, but does not provide as much information as the console based workflow.