### PR TITLE
Automatically map whatever DS is present.

### DIFF
--- a/pkg/fms/fms.go
+++ b/pkg/fms/fms.go
@@ -95,6 +95,7 @@ func New(opts ...Option) (*FMS, error) {
 		r.Route("/field", func(r chi.Router) {
 			r.Get("/configured-quads", x.configuredQuads)
 			r.Get("/present/{field}/{quad}", x.apiGetTeamPresent)
+			r.Get("/present", x.apiGetTeamPresentAll)
 		})
 		r.Route("/map", func(r chi.Router) {
 			r.Get("/current", x.apiGetCurrentMap)

--- a/pkg/fms/fms.go
+++ b/pkg/fms/fms.go
@@ -39,6 +39,8 @@ func New(opts ...Option) (*FMS, error) {
 	x.dsMeta = make(map[int]config.DSMeta)
 	x.connectedMutex = new(sync.RWMutex)
 	x.metaMutex = new(sync.RWMutex)
+	x.dsPresent = make(map[string]int)
+	x.dsPresentMutex = new(sync.RWMutex)
 	x.stop = make(chan struct{})
 	x.hudVersions = hudVersions{
 		HardwareVersions: "GIZMO_V00_R6E,GIZMO_V1_0_R00",
@@ -53,6 +55,7 @@ func New(opts ...Option) (*FMS, error) {
 			return nil, err
 		}
 	}
+	x.l.Debug("Quads Configured", "quads", x.quads)
 
 	var err error
 	x.s, err = http.NewServer(http.WithLogger(x.l), http.WithStartupWG(x.swg))
@@ -91,6 +94,7 @@ func New(opts ...Option) (*FMS, error) {
 		r.Get("/eventstream", x.es.Handler)
 		r.Route("/field", func(r chi.Router) {
 			r.Get("/configured-quads", x.configuredQuads)
+			r.Get("/present/{field}/{quad}", x.apiGetTeamPresent)
 		})
 		r.Route("/map", func(r chi.Router) {
 			r.Get("/current", x.apiGetCurrentMap)

--- a/pkg/fms/fms.go
+++ b/pkg/fms/fms.go
@@ -102,6 +102,7 @@ func New(opts ...Option) (*FMS, error) {
 			r.Get("/stage", x.apiGetStageMap)
 			r.Post("/stage", x.apiUpdateStageMap)
 			r.Post("/commit-stage", x.apiCommitStageMap)
+			r.Post("/update-immediate", x.apiUpdateMapImmediate)
 		})
 
 		r.Route("/setup", func(r chi.Router) {

--- a/pkg/fms/gizmo.go
+++ b/pkg/fms/gizmo.go
@@ -41,6 +41,18 @@ func (f *FMS) doConnectedUpkeep() {
 			}
 			f.metaMutex.Unlock()
 			f.connectedMutex.Unlock()
+
+			f.dsPresentMutex.Lock()
+			for _, quad := range f.quads {
+				delete(f.dsPresent, quad)
+				t, err := f.tlm.GetActualDS(quad)
+				if err != nil {
+					f.l.Trace("Error pulling from field", "error", err)
+					continue
+				}
+				f.dsPresent[quad] = t
+			}
+			f.dsPresentMutex.Unlock()
 		}
 	}
 }

--- a/pkg/fms/types.go
+++ b/pkg/fms/types.go
@@ -21,6 +21,8 @@ import (
 // number.
 type TeamLocationMapper interface {
 	GetFieldForTeam(int) (string, error)
+	GetActualDS(string) (int, error)
+
 	GetCurrentMapping() (map[int]string, error)
 	InsertOnDemandMap(map[int]string) error
 
@@ -95,6 +97,8 @@ type FMS struct {
 	gizmoMeta      map[int]config.GizmoMeta
 	dsMeta         map[int]config.DSMeta
 	metaMutex      *sync.RWMutex
+	dsPresent      map[string]int
+	dsPresentMutex *sync.RWMutex
 
 	netinst *netinstall.Installer
 

--- a/pkg/fms/ui/p2/views/map/current.p2
+++ b/pkg/fms/ui/p2/views/map/current.p2
@@ -1,29 +1,50 @@
 {% extends "../../base.p2" %}
 
-{% block title %}Current Field Mapping | Gizmo FMS{% endblock %}
+{% block title %}Active Field Mapping | Gizmo FMS{% endblock %}
 
 {% block content %}
-  <div class="flex-container flex-row flex-center">
+<div class="flex-container flex-row flex-center">
     <div class="flex-item flex-max foreground box">
-      <table>
-        <tr>
-          <th>Field</th>
-          <th>Position</th>
-          <th>Current</th>
-        </tr>
-        {% for q in quads %}
-          <tr>
-            <td>{{ q|split:":"|first|cut:"field" }}</td>
-            <td>{{ q|split:":"|last|capfirst }}</td>
-            <td>
-              {% if active[q] %}
-                {{ active[q] }} ({{ teams[active[q]]|teamName }})
-              {% else %}
-                No Team
-              {% endif %}
-            </td>
-          {% endfor %}
-      </table>
+        <table>
+            <tr>
+                <th>Field</th>
+                <th>Position</th>
+                <th>Expected</th>
+                <th>Actual</th>
+            </tr>
+            {% for q in quads %}
+            <tr>
+                <td>{{ q|split:":"|first|cut:"field" }}</td>
+                <td>{{ q|split:":"|last|capfirst }}</td>
+                <td>
+                    {% if active[q] %}
+                    {{ active[q] }} ({{ teams[active[q]]|teamName }})
+                    {% else %}
+                    No Team
+                    {% endif %}
+                </td>
+                <td id="{{ q }}">No Team</td>
+                {% endfor %}
+        </table>
     </div>
-  </div>
+</div>
+
+<script>
+ const quads = {{ quadJSON|safe }};
+ async function updateActual() {
+     const resp = await fetch('/api/field/present');
+     const data = await resp.json();
+     for (quad of quads) {
+         const qCell = document.getElementById(quad)
+         if (quad in data) {
+             qCell.innerHTML = data[quad];
+         } else {
+             qCell.innerHTML = 'No Team';
+         }
+     }
+     setTimeout(updateActual, 2000)
+ }
+
+ updateActual();
+</script>
 {% endblock %}

--- a/pkg/fms/ui/p2/views/map/stage.p2
+++ b/pkg/fms/ui/p2/views/map/stage.p2
@@ -3,44 +3,87 @@
 {% block title %}Stage Field Mapping | Gizmo FMS{% endblock %}
 
 {% block content %}
-  <div class="flex-container flex-row flex-center">
+<div class="flex-container flex-row flex-center">
     <div class="flex-item flex-max foreground box">
-      <form id="stageform" method="post">
-        <table>
-          <tr>
-            <th>Field</th>
-            <th>Position</th>
-            <th>Current</th>
-            <th>Staged</th>
-          </tr>
-          {% for q in quads %}
-            <tr>
-              <td>{{ q|split:":"|first|cut:"field" }}</td>
-              <td>{{ q|split:":"|last|capfirst }}</td>
-              <td>
-                {% if active[q] %}
-                  {{ active[q] }} ({{ teams[active[q]]|teamName }})
-                {% else %}
-                  No Team
-                {% endif %}
-              </td>
-              <td>
-                <select name="{{ q }}">
-                  <option value="0" {% if not stage[q] %}selected{% endif %}>Empty</option>
-                  {% for team in roster %}
-                    <option value="{{ team.Number }}" {% if team.Number == stage[q] %}selected{% endif %}>{{ team.Number }} ({{ team.Name }})</option>
-                  {% endfor %}
-                </select>
-              </td>
-            </tr>
-          {% endfor %}
-        </table>
-      </form>
-      <form id="commitform" method="post" action="/ui/admin/map/commit-stage"></form>
-      <div class="flex-container flex-row flex-center">
-        <input form="stageform" type="submit" value="Save Stage Map" class="flex-item button" />
-        <input form="commitform" type="submit" value="Commit Staging Map" class="flex-item button" />
-      </div>
+        <form id="stageform" method="post">
+            <table>
+                <tr>
+                    <th>Field</th>
+                    <th>Position</th>
+                    <th>Current</th>
+                    <th>Staged</th>
+                    <th>Actual</th>
+                </tr>
+                {% for q in quads %}
+                <tr>
+                    <td>{{ q|split:":"|first|cut:"field" }}</td>
+                    <td>{{ q|split:":"|last|capfirst }}</td>
+                    <td>
+                        {% if active[q] %}
+                        {{ active[q] }} ({{ teams[active[q]]|teamName }})
+                        {% else %}
+                        No Team
+                        {% endif %}
+                    </td>
+                    <td>
+                        <select name="{{ q }}">
+                            <option value="0" {% if not stage[q] %}selected{% endif %}>Empty</option>
+                            {% for team in roster %}
+                            <option value="{{ team.Number }}" {% if team.Number == stage[q] %}selected{% endif %}>{{ team.Number }} ({{ team.Name }})</option>
+                            {% endfor %}
+                        </select>
+                    </td>
+                    <td id="{{ q }}"></td>
+                </tr>
+                {% endfor %}
+            </table>
+        </form>
+        <form id="commitform" method="post" action="/ui/admin/map/commit-stage"></form>
+        <div class="flex-container flex-row flex-center">
+            <input form="stageform" type="submit" value="Save Stage Map" class="flex-item button" />
+            <input form="commitform" type="submit" value="Commit Staging Map" class="flex-item button" />
+            <button id="btn-map-actual" class="flex-item button">Map Teams Present</button>
+        </div>
     </div>
-  </div>
+</div>
+
+<script>
+ const quads = {{ quadJSON|safe }};
+ async function updateActual() {
+     const resp = await fetch('/api/field/present');
+     const data = await resp.json();
+     for (quad of quads) {
+         const qCell = document.getElementById(quad)
+         if (quad in data) {
+             qCell.innerHTML = data[quad];
+         } else {
+             qCell.innerHTML = 'No Team';
+         }
+     }
+     setTimeout(updateActual, 2000)
+ }
+
+ async function mapActual() {
+     const resp = await fetch('/api/field/present');
+     const data = await resp.json();
+     const map = new Map();
+
+     for (quad in data) {
+         map.set(data[quad], quad);
+     }
+     const newMapping = Object.fromEntries(map);
+     console.log(newMapping);
+     const response = await fetch('/api/map/update-immediate', {
+         method: 'POST',
+         headers: { 'Content-Type': 'application/json' },
+         body: JSON.stringify(newMapping),
+     });
+     if (resp.ok) {
+         window.location.reload(true);
+     }
+ }
+ document.getElementById('btn-map-actual').addEventListener('click', mapActual);
+
+ updateActual();
+</script>
 {% endblock %}

--- a/pkg/fms/web.go
+++ b/pkg/fms/web.go
@@ -20,6 +20,15 @@ func (f *FMS) apiGetConfig(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(f.c)
 }
 
+func (f *FMS) apiGetTeamPresent(w http.ResponseWriter, r *http.Request) {
+	field := chi.URLParam(r, "field")
+	quad := chi.URLParam(r, "quad")
+	f.dsPresentMutex.RLock()
+	num := f.dsPresent["field"+field+":"+quad]
+	f.dsPresentMutex.RUnlock()
+	json.NewEncoder(w).Encode(num)
+}
+
 func (f *FMS) apiGetCurrentMap(w http.ResponseWriter, r *http.Request) {
 	m, _ := f.tlm.GetCurrentMapping()
 	json.NewEncoder(w).Encode(m)

--- a/pkg/fms/web.go
+++ b/pkg/fms/web.go
@@ -29,6 +29,12 @@ func (f *FMS) apiGetTeamPresent(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(num)
 }
 
+func (f *FMS) apiGetTeamPresentAll(w http.ResponseWriter, r *http.Request) {
+	f.dsPresentMutex.RLock()
+	defer f.dsPresentMutex.RUnlock()
+	json.NewEncoder(w).Encode(f.dsPresent)
+}
+
 func (f *FMS) apiGetCurrentMap(w http.ResponseWriter, r *http.Request) {
 	m, _ := f.tlm.GetCurrentMapping()
 	json.NewEncoder(w).Encode(m)

--- a/pkg/fms/web_ui.go
+++ b/pkg/fms/web_ui.go
@@ -44,12 +44,14 @@ func (f *FMS) uiViewStageMap(w http.ResponseWriter, r *http.Request) {
 		f.doTemplate(w, r, "errors/internal.p2", pongo2.Context{"error": err})
 	}
 
+	out, _ := json.Marshal(f.quads)
 	ctx := pongo2.Context{
-		"stage":  f.invertTLMMap(stage),
-		"active": f.invertTLMMap(current),
-		"quads":  f.quads,
-		"teams":  f.c.Teams,
-		"roster": f.c.SortedTeams(),
+		"stage":    f.invertTLMMap(stage),
+		"active":   f.invertTLMMap(current),
+		"quads":    f.quads,
+		"teams":    f.c.Teams,
+		"roster":   f.c.SortedTeams(),
+		"quadJSON": string(out),
 	}
 
 	f.doTemplate(w, r, "views/map/stage.p2", ctx)

--- a/pkg/fms/web_ui.go
+++ b/pkg/fms/web_ui.go
@@ -1,6 +1,7 @@
 package fms
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -21,10 +22,12 @@ func (f *FMS) uiViewCurrentMap(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		f.doTemplate(w, r, "errors/internal.p2", pongo2.Context{"error": err})
 	}
+	out, _ := json.Marshal(f.quads)
 	ctx := pongo2.Context{
-		"quads":  f.quads,
-		"active": f.invertTLMMap(m),
-		"teams":  f.c.Teams,
+		"quads":    f.quads,
+		"quadJSON": string(out),
+		"active":   f.invertTLMMap(m),
+		"teams":    f.c.Teams,
 	}
 
 	f.doTemplate(w, r, "views/map/current.p2", ctx)

--- a/pkg/routeros/config/type.go
+++ b/pkg/routeros/config/type.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"embed"
+	"net/http"
 
 	"github.com/hashicorp/go-hclog"
 
@@ -30,6 +31,7 @@ type Configurator struct {
 	l  hclog.Logger
 	fc *config.FMSConfig
 	es EventStreamer
+	cl *http.Client
 
 	stateDir string
 
@@ -52,4 +54,10 @@ type rosCapInterface struct {
 
 type rosRemoteCap struct {
 	ID string `json:".id"`
+}
+
+type rosNeighbor struct {
+	ID        string `json:".id"`
+	Identity  string `json:"identity"`
+	Interface string `json:"interface"`
 }

--- a/pkg/tlm/net/net.go
+++ b/pkg/tlm/net/net.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
@@ -53,6 +55,21 @@ func (tlm *TLM) GetFieldForTeam(team int) (string, error) {
 		return "none:none", errors.New("no mapping for team")
 	}
 	return mapping, nil
+}
+
+// GetActualDS figures out what team is actually connected to
+// a given field port.  This is based on checking for some LLDP
+// signaling so that even if no VLAN is mapped for IP communication,
+// the driver's stations are all named in a predictable pattern.
+func (tlm *TLM) GetActualDS(fID string) (int, error) {
+	parts := strings.Split(fID, ":")
+	num, _ := strconv.Atoi(strings.TrimPrefix(parts[0], "field"))
+
+	team, err := tlm.controller.GetIDOnPort(num, parts[1])
+	if err != nil {
+		return -1, err
+	}
+	return team, nil
 }
 
 // InsertOnDemandMap inserts an on-demand mapping that overrides any


### PR DESCRIPTION
This patch set adds a button in the stage mapping screen to take whatever set of driver's stations are connected right now and make that the active mapping.  This is identified using LLDP, so the current mapping doesn't matter as the DS is able to pass its identity back on layer 2 rather than the (potentially incorrect) layer 3.

Resolves #68 

Here's a screen recording of what this looks like.  The recording starts with no DS connected, then I plug #452 into the green field connector.

[automap.webm](https://github.com/user-attachments/assets/f1602c60-63f7-4e49-b82b-7c4a82483ae8)
